### PR TITLE
feat(kill-process): support battery sorting

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "defaultBase": "master",
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
@@ -12,8 +13,10 @@
       "!{projectRoot}/src/test-setup.[jt]s",
       "!{projectRoot}/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/release-master.yaml"]
+    "sharedGlobals": ["{workspaceRoot}/.github/workflows/release-master.yaml"],
+    "plugins": ["{workspaceRoot}/projects/workspace/src/plugins/**"]
   },
+  "plugins": ["@alfredo/workspace"],
   "targetDefaults": {
     "@nx/esbuild:esbuild": {
       "executor": "@nx/esbuild:esbuild",

--- a/projects/libs/llm/src/lib/available-models.enum.ts
+++ b/projects/libs/llm/src/lib/available-models.enum.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export enum AvailableModels {
   /* Anthropic */
   CLAUDE_OPUS_4 = 'claude-opus-4-0',
@@ -27,3 +29,5 @@ export enum AvailableModels {
   O3 = 'o3',
   O3_MINI = 'o3-mini',
 }
+
+export const AvailableModelsSchema = z.nativeEnum(AvailableModels);

--- a/projects/packages/ai-calendar-assistant/src/main/create-event.ts
+++ b/projects/packages/ai-calendar-assistant/src/main/create-event.ts
@@ -2,7 +2,7 @@ import { FastAlfred } from 'fast-alfred';
 import { runAppleScript } from '@alfredo/run-applescript';
 import { Variables } from '../common/variables.enum';
 import { CalendarEvent, GeminiCalendarEventSchema } from '../models/calendar-event.model';
-import { OpenEventPlatform } from '../models/open-event-platform.enum';
+import { OpenEventPlatform, OpenEventPlatformSchema } from '../models/open-event-platform.enum';
 import { createInCalendar, eventCreatorAppleScript } from '../services/event-creator.service';
 
 (async () => {
@@ -19,9 +19,11 @@ import { createInCalendar, eventCreatorAppleScript } from '../services/event-cre
     parser: (value) => (value as '0' | '1') === '1',
   });
 
-  const openEventPlatform: OpenEventPlatform = alfredClient.env.getEnv(Variables.OPEN_NEW_EVENT_PLATFORM, {
-    defaultValue: OpenEventPlatform.APPLE_CALENDAR,
-  });
+  const openEventPlatform = OpenEventPlatformSchema.parse(
+    alfredClient.env.getEnv(Variables.OPEN_NEW_EVENT_PLATFORM, {
+      defaultValue: OpenEventPlatform.APPLE_CALENDAR,
+    }),
+  );
 
   const event: CalendarEvent = JSON.parse(alfredClient.input);
   const parsedEvent = GeminiCalendarEventSchema.parse(event);

--- a/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
+++ b/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
@@ -1,6 +1,6 @@
 import { AlfredListItem, FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
-import { AvailableModels } from '@alfredo/llm';
+import { AvailableModelsSchema } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { Variables } from '../common/variables.enum';
@@ -19,7 +19,8 @@ import { extractEvent } from '../services/event-extractor.service';
     });
 
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/ai-calendar-assistant/src/models/open-event-platform.enum.ts
+++ b/projects/packages/ai-calendar-assistant/src/models/open-event-platform.enum.ts
@@ -1,4 +1,8 @@
+import { z } from 'zod';
+
 export enum OpenEventPlatform {
   GOOGLE_CALENDAR = 'google_calendar',
   APPLE_CALENDAR = 'apple_calendar',
 }
+
+export const OpenEventPlatformSchema = z.nativeEnum(OpenEventPlatform);

--- a/projects/packages/jira-master/src/main/extract-jira-ticket.ts
+++ b/projects/packages/jira-master/src/main/extract-jira-ticket.ts
@@ -1,6 +1,6 @@
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
-import type { AvailableModels } from '@alfredo/llm';
+import { AvailableModelsSchema } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { Variables } from '../common/variables.enum';
@@ -25,7 +25,8 @@ import { extractTicket } from '../services/ticket-extractor.service';
     }
 
     const llmToken = alfredClient.env.getEnv<string>(Variables.LLM_TOKEN);
-    const selectedModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL) as AvailableModels;
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const selectedModel = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!llmToken || !selectedModel) {
       throw new Error(

--- a/projects/packages/kill-process/.fast-alfred.config.cjs
+++ b/projects/packages/kill-process/.fast-alfred.config.cjs
@@ -26,8 +26,9 @@ Search through your operating system's processes by name, port, PID, or path –
 
 #### With resource consumption sorting
 
-\`!m\` - Search for processes, sorted by memory usage.   
+\`!m\` - Search for processes, sorted by memory usage.    
 \`!c\` - Search for processes, sorted by CPU usage.   
+\`!b\` - Search for processes, sorted by battery usage (requires one-time password for setup).    
 
 
 To view the workflow codebase, click here:

--- a/projects/packages/kill-process/info.plist
+++ b/projects/packages/kill-process/info.plist
@@ -21,6 +21,19 @@
       </array>
       <key>14799482-DEFB-419D-8A33-CE6F4B12614B</key>
       <array></array>
+      <key>2082DD8A-72BD-4436-84F1-713DE3744EF7</key>
+      <array>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_conditional_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+        </dict>
+      </array>
       <key>5237AB6B-76A7-4B1E-80E4-C3CE1D5F52FE</key>
       <array>
         <dict>
@@ -180,6 +193,43 @@
           <false></false>
           <key>sourceoutputuid</key>
           <string>__fast-alfred_managed__v2_condition_from_5237AB6B-76A7-4B1E-80E4-C3CE1D5F52FE_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_updater_snooze</string>
+        </dict>
+      </array>
+      <key>__fast-alfred_managed__v2_conditional_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</key>
+      <array>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>destinationuid</key>
+          <string>14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+        </dict>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>sourceoutputuid</key>
+          <string>__fast-alfred_managed__v2_condition_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_updater_workflow-update</string>
+        </dict>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>sourceoutputuid</key>
+          <string>__fast-alfred_managed__v2_condition_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
           <key>destinationuid</key>
           <string>__fast-alfred_managed__v2_updater_snooze</string>
         </dict>
@@ -356,7 +406,7 @@
           <key>subtext</key>
           <string></string>
           <key>title</key>
-          <string>Kill a process</string>
+          <string>Kill a process - sort by memory</string>
           <key>type</key>
           <integer>11</integer>
           <key>withspace</key>
@@ -429,7 +479,7 @@
           <key>subtext</key>
           <string></string>
           <key>title</key>
-          <string>Kill a process</string>
+          <string>Kill a process - sort by CPU</string>
           <key>type</key>
           <integer>11</integer>
           <key>withspace</key>
@@ -439,6 +489,56 @@
         <string>alfred.workflow.input.scriptfilter</string>
         <key>uid</key>
         <string>5237AB6B-76A7-4B1E-80E4-C3CE1D5F52FE</string>
+        <key>version</key>
+        <integer>3</integer>
+      </dict>
+      <dict>
+        <key>config</key>
+        <dict>
+          <key>alfredfiltersresults</key>
+          <false></false>
+          <key>alfredfiltersresultsmatchmode</key>
+          <integer>0</integer>
+          <key>argumenttreatemptyqueryasnil</key>
+          <true></true>
+          <key>argumenttrimmode</key>
+          <integer>0</integer>
+          <key>argumenttype</key>
+          <integer>1</integer>
+          <key>escaping</key>
+          <integer>102</integer>
+          <key>keyword</key>
+          <string>!b</string>
+          <key>queuedelaycustom</key>
+          <integer>3</integer>
+          <key>queuedelayimmediatelyinitially</key>
+          <true></true>
+          <key>queuedelaymode</key>
+          <integer>0</integer>
+          <key>queuemode</key>
+          <integer>2</integer>
+          <key>runningsubtext</key>
+          <string>Searching...</string>
+          <key>script</key>
+          <string>./esbuild/assets/run-node.sh esbuild/find-process.js "false" "battery" "$1"
+</string>
+          <key>scriptargtype</key>
+          <integer>1</integer>
+          <key>scriptfile</key>
+          <string></string>
+          <key>subtext</key>
+          <string></string>
+          <key>title</key>
+          <string>Kill a process - sort by battery usage</string>
+          <key>type</key>
+          <integer>11</integer>
+          <key>withspace</key>
+          <true></true>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.input.scriptfilter</string>
+        <key>uid</key>
+        <string>2082DD8A-72BD-4436-84F1-713DE3744EF7</string>
         <key>version</key>
         <integer>3</integer>
       </dict>
@@ -688,6 +788,38 @@
         <key>type</key>
         <string>alfred.workflow.utility.conditional</string>
         <key>uid</key>
+        <string>__fast-alfred_managed__v2_conditional_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+        <key>version</key>
+        <integer>1</integer>
+        <key>config</key>
+        <dict>
+          <key>conditions</key>
+          <array>
+            <dict>
+              <key>inputstring</key>
+              <string>{query}</string>
+              <key>matchcasesensitive</key>
+              <false></false>
+              <key>matchmode</key>
+              <integer>4</integer>
+              <key>matchstring</key>
+              <string>__fast-alfred_managed__</string>
+              <key>outputlabel</key>
+              <string>Managed versions updates</string>
+              <key>uid</key>
+              <string>__fast-alfred_managed__v2_condition_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
+            </dict>
+          </array>
+          <key>elselabel</key>
+          <string>Default Behavior</string>
+          <key>hideelse</key>
+          <false></false>
+        </dict>
+      </dict>
+      <dict>
+        <key>type</key>
+        <string>alfred.workflow.utility.conditional</string>
+        <key>uid</key>
         <string>__fast-alfred_managed__v2_conditional_from_8A785DFD-30FA-43E2-BF07-9B1B46F29B63_to_14799482-DEFB-419D-8A33-CE6F4B12614B</string>
         <key>version</key>
         <integer>1</integer>
@@ -773,8 +905,9 @@ Search through your operating system's processes by name, port, PID, or path –
 
 #### With resource consumption sorting
 
-`!m` - Search for processes, sorted by memory usage.   
+`!m` - Search for processes, sorted by memory usage.    
 `!c` - Search for processes, sorted by CPU usage.   
+`!b` - Search for processes, sorted by battery usage (requires one-time password for setup).    
 
 
 To view the workflow codebase, click here:
@@ -788,7 +921,7 @@ https://github.com/Avivbens/alfredo</string>
         <key>xpos</key>
         <integer>65</integer>
         <key>ypos</key>
-        <integer>780</integer>
+        <integer>1015</integer>
       </dict>
       <key>14799482-DEFB-419D-8A33-CE6F4B12614B</key>
       <dict>
@@ -796,6 +929,15 @@ https://github.com/Avivbens/alfredo</string>
         <integer>495</integer>
         <key>ypos</key>
         <integer>240</integer>
+      </dict>
+      <key>2082DD8A-72BD-4436-84F1-713DE3744EF7</key>
+      <dict>
+        <key>note</key>
+        <string>Kill process (CPU sort)</string>
+        <key>xpos</key>
+        <integer>65</integer>
+        <key>ypos</key>
+        <integer>585</integer>
       </dict>
       <key>5237AB6B-76A7-4B1E-80E4-C3CE1D5F52FE</key>
       <dict>
@@ -822,7 +964,7 @@ https://github.com/Avivbens/alfredo</string>
         <key>xpos</key>
         <integer>65</integer>
         <key>ypos</key>
-        <integer>600</integer>
+        <integer>835</integer>
       </dict>
       <key>CE84ED38-CD11-4B81-9E07-91C9D10EEE3C</key>
       <dict>
@@ -878,12 +1020,21 @@ https://github.com/Avivbens/alfredo</string>
         <key>note</key>
         <string>Conditional Updates Helper</string>
       </dict>
+      <key>__fast-alfred_managed__v2_conditional_from_2082DD8A-72BD-4436-84F1-713DE3744EF7_to_14799482-DEFB-419D-8A33-CE6F4B12614B</key>
+      <dict>
+        <key>xpos</key>
+        <integer>285</integer>
+        <key>ypos</key>
+        <integer>585</integer>
+        <key>note</key>
+        <string>Conditional Updates Helper</string>
+      </dict>
       <key>__fast-alfred_managed__v2_conditional_from_8A785DFD-30FA-43E2-BF07-9B1B46F29B63_to_14799482-DEFB-419D-8A33-CE6F4B12614B</key>
       <dict>
         <key>xpos</key>
         <integer>285</integer>
         <key>ypos</key>
-        <integer>600</integer>
+        <integer>835</integer>
         <key>note</key>
         <string>Conditional Updates Helper</string>
       </dict>
@@ -892,7 +1043,7 @@ https://github.com/Avivbens/alfredo</string>
         <key>xpos</key>
         <integer>285</integer>
         <key>ypos</key>
-        <integer>780</integer>
+        <integer>1015</integer>
         <key>note</key>
         <string>Conditional Updates Helper</string>
       </dict>
@@ -1020,7 +1171,7 @@ https://github.com/Avivbens/alfredo</string>
       </dict>
     </array>
     <key>version</key>
-    <string>2.3.0</string>
+    <string>3.0.0</string>
     <key>webaddress</key>
     <string>https://github.com/Avivbens/alfredo</string>
     <key>category</key>

--- a/projects/packages/kill-process/src/models/battery-fetch-result.model.ts
+++ b/projects/packages/kill-process/src/models/battery-fetch-result.model.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const BatteryFetchResultSchema = z.object({
+  success: z.boolean(),
+  data: z.map(z.number(), z.number()),
+  error: z.string().optional(),
+});
+
+export type BatteryFetchResult = z.infer<typeof BatteryFetchResultSchema>;

--- a/projects/packages/kill-process/src/models/process-with-battery.model.ts
+++ b/projects/packages/kill-process/src/models/process-with-battery.model.ts
@@ -1,0 +1,12 @@
+import type { ProcessDescriptor } from 'ps-list';
+
+/**
+ * Extended process descriptor that includes battery/energy impact data from powermetrics
+ */
+export interface ProcessWithBattery extends ProcessDescriptor {
+  /**
+   * Energy impact value from powermetrics command
+   * Undefined if battery data is not available or not fetched
+   */
+  battery?: number;
+}

--- a/projects/packages/kill-process/src/models/sort-by-resources.model.ts
+++ b/projects/packages/kill-process/src/models/sort-by-resources.model.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const SortByResourceSchema = z.enum(['cpu', 'memory', 'none']);
+export const SortByResourceSchema = z.enum(['cpu', 'memory', 'battery', 'none']);
 export type SortByResource = z.infer<typeof SortByResourceSchema>;
 
 const DEFAULT_SORT_BY_RESOURCE: SortByResource = 'none';

--- a/projects/packages/kill-process/src/models/sort-by-resources.model.ts
+++ b/projects/packages/kill-process/src/models/sort-by-resources.model.ts
@@ -1,11 +1,11 @@
-export const SORT_BY_RESOURCE_OPTIONS = ['cpu', 'memory', 'none'] as const;
-export type SortByResource = (typeof SORT_BY_RESOURCE_OPTIONS)[number];
+import { z } from 'zod';
+
+export const SortByResourceSchema = z.enum(['cpu', 'memory', 'none']);
+export type SortByResource = z.infer<typeof SortByResourceSchema>;
 
 const DEFAULT_SORT_BY_RESOURCE: SortByResource = 'none';
 
 export const getSortByResource = (input: string): SortByResource => {
-  const value = input.toLowerCase();
-  return SORT_BY_RESOURCE_OPTIONS.includes(value as SortByResource)
-    ? (value as SortByResource)
-    : DEFAULT_SORT_BY_RESOURCE;
+  const result = SortByResourceSchema.safeParse(input.toLowerCase());
+  return result.success ? result.data : DEFAULT_SORT_BY_RESOURCE;
 };

--- a/projects/packages/kill-process/src/services/battery.service.ts
+++ b/projects/packages/kill-process/src/services/battery.service.ts
@@ -1,0 +1,161 @@
+import { $ } from 'zurk';
+import { BatteryFetchResult, BatteryFetchResultSchema } from '../models/battery-fetch-result.model';
+import { ensurePasswordlessSudo } from './sudo-setup.service';
+
+/**
+ * Fetches battery/energy impact data for all running processes
+ * Uses sudo powermetrics and parses the first sample only
+ *
+ * @returns Result object with success status, data map, and optional error message
+ */
+export async function fetchBatteryData(): Promise<BatteryFetchResult> {
+  try {
+    const sudoCheck = await ensurePasswordlessSudo();
+    if (!sudoCheck.success) {
+      return BatteryFetchResultSchema.parse({
+        success: false,
+        data: new Map(),
+        error: sudoCheck.error || 'Failed to configure passwordless sudo for powermetrics',
+      });
+    }
+
+    // Execute powermetrics with sudo
+    // --samplers tasks: Only collect task/process data
+    // --show-process-energy: Include energy impact column
+    // -n 1: Take only 1 sample
+    // -i 2500: Sample interval 2.5 seconds (provides accurate energy measurements)
+    const { stdout, stderr } = await $({
+      timeout: 6000, // 6 second timeout (allows for 2.5s sampling + buffer)
+      nothrow: true,
+    })`sudo powermetrics --samplers tasks --show-process-energy -n 1 -i 2500`;
+
+    if (stderr && !stdout) {
+      return BatteryFetchResultSchema.parse({
+        success: false,
+        data: new Map(),
+        error: `Powermetrics error: ${stderr}`,
+      });
+    }
+
+    // Parse the output
+    const batteryMap = parsePowermetricsOutput(stdout);
+
+    const result = {
+      success: true,
+      data: batteryMap,
+    };
+
+    return BatteryFetchResultSchema.parse(result);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return BatteryFetchResultSchema.parse({
+      success: false,
+      data: new Map(),
+      error: `Failed to fetch battery data: ${errorMessage}`,
+    });
+  }
+}
+
+/**
+ * Parses powermetrics output to extract PID and Energy Impact
+ *
+ * Expected format:
+ * *** Running tasks ***
+ *
+ * Name                               ID     CPU ms/s  User%  Deadlines (<2 ms, 2-5 ms)  Wakeups (Intr, Pkg idle)  Energy Impact
+ * Google Chrome Helper (Renderer)    73924  56.45     97.12  0.40    0.20               6.58    0.00              267.69
+ *
+ * @param output - Raw stdout from powermetrics
+ * @returns Map of PID to energy impact value
+ */
+function parsePowermetricsOutput(output: string): Map<number, number> {
+  const batteryMap = new Map<number, number>();
+
+  if (!output) {
+    return batteryMap;
+  }
+
+  const lines = output.split('\n');
+  let inTasksSection = false;
+  let headerPassed = false;
+
+  for (const line of lines) {
+    // Detect start of tasks section
+    if (line.includes('*** Running tasks ***')) {
+      inTasksSection = true;
+      continue;
+    }
+
+    // Skip until we're in the tasks section
+    if (!inTasksSection) {
+      continue;
+    }
+
+    // Skip the header line
+    if (line.includes('Energy Impact') && line.includes('Name')) {
+      headerPassed = true;
+      continue;
+    }
+
+    // Skip if we haven't passed the header yet
+    if (!headerPassed) {
+      continue;
+    }
+
+    // Skip empty lines
+    if (!line.trim()) {
+      continue;
+    }
+
+    // Parse data line
+    // Format: Name (spaces) PID (spaces) ... (spaces) EnergyImpact
+    // We need to extract the last number (Energy Impact) and the ID column
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Split by whitespace and filter empty strings
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+
+    // Need at least: Name, ID, and other columns ending with Energy Impact
+    // Typically: [Name(s), ID, CPU, User%, Deadlines..., Wakeups..., EnergyImpact]
+    if (parts.length < 3) {
+      continue;
+    }
+
+    try {
+      // The ID is typically the second column after name(s)
+      // Try to find the first numeric value that could be a PID
+      let pidIndex = -1;
+      let pid = 0;
+
+      for (let i = 1; i < parts.length; i++) {
+        const part = parts[i];
+        if (!part) continue;
+        const parsed = parseInt(part, 10);
+        if (!isNaN(parsed) && parsed > 0) {
+          pid = parsed;
+          pidIndex = i;
+          break;
+        }
+      }
+
+      if (pidIndex === -1) {
+        continue;
+      }
+
+      // Energy Impact is the last column
+      const lastPart = parts[parts.length - 1];
+      if (!lastPart) continue;
+      const energyImpact = parseFloat(lastPart);
+
+      if (!isNaN(energyImpact) && energyImpact >= 0) {
+        batteryMap.set(pid, energyImpact);
+      }
+    } catch {
+      // Skip malformed lines
+      continue;
+    }
+  }
+
+  return batteryMap;
+}

--- a/projects/packages/kill-process/src/services/process-merger.service.ts
+++ b/projects/packages/kill-process/src/services/process-merger.service.ts
@@ -1,0 +1,23 @@
+import type { ProcessDescriptor } from 'ps-list';
+import type { ProcessWithBattery } from '../models/process-with-battery.model';
+
+/**
+ * Merges battery data into process list
+ *
+ * @param processes - Process list from ps-list
+ * @param batteryData - Map of PID to energy impact value
+ * @returns Processes with battery data merged in
+ */
+export function mergeProcessesWithBattery(
+  processes: ProcessDescriptor[],
+  batteryData: Map<number, number>,
+): ProcessWithBattery[] {
+  return processes.map((process) => {
+    const battery = batteryData.get(process.pid);
+
+    return {
+      ...process,
+      battery: battery !== undefined ? battery : undefined,
+    };
+  });
+}

--- a/projects/packages/kill-process/src/services/sudo-setup.service.ts
+++ b/projects/packages/kill-process/src/services/sudo-setup.service.ts
@@ -1,0 +1,107 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { $ } from 'zurk';
+
+/**
+ * Checks if passwordless sudo is configured for powermetrics
+ * @returns true if passwordless sudo is configured, false otherwise
+ */
+async function checkPasswordlessSudo(): Promise<boolean> {
+  try {
+    // Check if sudoers file exists
+    const sudoersPath = '/etc/sudoers.d/powermetrics';
+    if (!existsSync(sudoersPath)) {
+      return false;
+    }
+
+    // Try to run powermetrics with sudo and check if it prompts for password
+    const { stdout, stderr } = await $({
+      timeout: 1000,
+      nothrow: true,
+    })`powermetrics --help`;
+
+    return !stderr.includes('password is required') && !stderr.includes('a password is required');
+  } catch (error) {
+    // Timeout or error means password is required
+    return false;
+  }
+}
+
+/**
+ * Sets up passwordless sudo for powermetrics
+ * @returns Result object with success status and optional error message
+ */
+async function setupPasswordlessSudo(): Promise<{ success: boolean; error?: string }> {
+  try {
+    const username = homedir().split('/').pop();
+    if (!username) {
+      return {
+        success: false,
+        error: 'Could not determine username',
+      };
+    }
+
+    const sudoersContent = `${username} ALL=(root) NOPASSWD: /usr/bin/powermetrics\n`;
+    const sudoersPath = '/etc/sudoers.d/powermetrics';
+
+    const tempFile = join(tmpdir(), `powermetrics-sudoers-${Date.now()}`);
+    writeFileSync(tempFile, sudoersContent, { mode: 0o440 });
+
+    /**
+     * Use sudo to move the temp file to sudoers.d
+     * This will prompt for password once
+     */
+    const { stderr } = await $({
+      timeout: 30000, // 30 seconds for user to enter password
+      nothrow: true,
+    })`sudo install -m 0440 -o root -g wheel ${tempFile} ${sudoersPath}`;
+
+    if (stderr && stderr.includes('Sorry')) {
+      return {
+        success: false,
+        error: 'Authentication failed or insufficient permissions',
+      };
+    }
+
+    // Verify the setup worked
+    const isConfigured = await checkPasswordlessSudo();
+    if (!isConfigured) {
+      return {
+        success: false,
+        error: 'Setup completed but verification failed',
+      };
+    }
+
+    return { success: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: `Failed to setup passwordless sudo: ${errorMessage}`,
+    };
+  }
+}
+
+/**
+ * Ensures passwordless sudo is configured, setting it up if necessary
+ * @returns Result object with success status and optional error message
+ */
+export async function ensurePasswordlessSudo(): Promise<{
+  success: boolean;
+  error?: string;
+  setupPerformed?: boolean;
+}> {
+  // First check if it's already configured
+  const isConfigured = await checkPasswordlessSudo();
+  if (isConfigured) {
+    return { success: true, setupPerformed: false };
+  }
+
+  // If not configured, attempt to set it up
+  const setupResult = await setupPasswordlessSudo();
+  return {
+    ...setupResult,
+    setupPerformed: setupResult.success,
+  };
+}

--- a/projects/packages/text-transformer/src/main/action-items.ts
+++ b/projects/packages/text-transformer/src/main/action-items.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { ACTION_ITEMS_SYSTEM_PROMPT } from '../common/prompts/action-items.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/beautify.ts
+++ b/projects/packages/text-transformer/src/main/beautify.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { BEAUTIFY_SYSTEM_PROMPT } from '../common/prompts/beautify.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/commit.ts
+++ b/projects/packages/text-transformer/src/main/commit.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { COMMIT_SYSTEM_PROMPT } from '../common/prompts/commit.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/explain.ts
+++ b/projects/packages/text-transformer/src/main/explain.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { EXPLAIN_SYSTEM_PROMPT } from '../common/prompts/explain.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/grammar.ts
+++ b/projects/packages/text-transformer/src/main/grammar.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { GRAMMAR_SYSTEM_PROMPT } from '../common/prompts/grammar.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/spell-check.ts
+++ b/projects/packages/text-transformer/src/main/spell-check.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { SPELL_CHECK_SYSTEM_PROMPT } from '../common/prompts/spell-check.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/summarize.ts
+++ b/projects/packages/text-transformer/src/main/summarize.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { SUMMARIZE_SYSTEM_PROMPT } from '../common/prompts/summarize.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/table.ts
+++ b/projects/packages/text-transformer/src/main/table.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { TABLE_SYSTEM_PROMPT } from '../common/prompts/table.prompt';
@@ -19,7 +19,8 @@ import { formatMarkdownTable } from '../utils/format-table.util';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/tldr.ts
+++ b/projects/packages/text-transformer/src/main/tldr.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModel } from '@alfredo/llm';
+import { AvailableModelsSchema, callModel } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { TLDR_SYSTEM_PROMPT } from '../common/prompts/tldr.prompt';
@@ -18,7 +18,8 @@ import { Variables } from '../common/variables.enum';
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/main/translate/translate.ts
+++ b/projects/packages/text-transformer/src/main/translate/translate.ts
@@ -2,7 +2,7 @@ import type { AlfredListItem } from 'fast-alfred';
 import { FastAlfred } from 'fast-alfred';
 import { setTimeout } from 'node:timers/promises';
 import { getActiveApp } from '@alfredo/active-app';
-import { AvailableModels, callModelWithStructuredResponse } from '@alfredo/llm';
+import { AvailableModelsSchema, callModelWithStructuredResponse } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME, LANGUAGE_DELIMITER } from '../../common/defaults.constants';
 import { TRANSLATE_SYSTEM_PROMPT } from '../../common/prompts/translate.prompt';
@@ -60,7 +60,8 @@ function parseLanguageFromInput(input: string): ParsedTranslationInput {
       parser: Number,
     });
     const token: string | undefined = alfredClient.env.getEnv(Variables.LLM_TOKEN);
-    const model: AvailableModels | undefined = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const rawModel = alfredClient.env.getEnv(Variables.SELECTED_MODEL);
+    const model = rawModel ? AvailableModelsSchema.parse(rawModel) : undefined;
 
     if (!token || !model) {
       throw new Error('Token or model is not defined!');

--- a/projects/packages/text-transformer/src/models/tones.enum.ts
+++ b/projects/packages/text-transformer/src/models/tones.enum.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export enum AvailableTone {
   CASUAL = 'casual',
   PROFESSIONAL = 'professional',
@@ -5,3 +7,5 @@ export enum AvailableTone {
   HAPPY = 'happy',
   SIMPLE = 'simple',
 }
+
+export const AvailableToneSchema = z.nativeEnum(AvailableTone);

--- a/projects/packages/toggle-audio-output/src/models/audio-source-all.model.ts
+++ b/projects/packages/toggle-audio-output/src/models/audio-source-all.model.ts
@@ -1,6 +1,10 @@
-export interface AudioSource {
-  name: string;
-  type: 'output' | 'input';
-  id: string;
-  uid: string;
-}
+import { z } from 'zod';
+
+export const AudioSourceSchema = z.object({
+  name: z.string(),
+  type: z.enum(['output', 'input']),
+  id: z.string(),
+  uid: z.string(),
+});
+
+export type AudioSource = z.infer<typeof AudioSourceSchema>;

--- a/projects/packages/toggle-audio-output/src/services/audio-connection.service.ts
+++ b/projects/packages/toggle-audio-output/src/services/audio-connection.service.ts
@@ -1,5 +1,5 @@
 import { $ } from 'zurk';
-import { AudioSource } from '../models/audio-source-all.model';
+import { AudioSource, AudioSourceSchema } from '../models/audio-source-all.model';
 
 export async function getConnectedAudioDevices(): Promise<AudioSource[]> {
   const { stdout } = await $`SwitchAudioSource -a -f json`;
@@ -8,7 +8,7 @@ export async function getConnectedAudioDevices(): Promise<AudioSource[]> {
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => JSON.parse(line)) as AudioSource[];
+    .map((line) => AudioSourceSchema.parse(JSON.parse(line)));
 
   return audioData || [];
 }

--- a/projects/workspace/package.json
+++ b/projects/workspace/package.json
@@ -2,6 +2,7 @@
   "name": "@alfredo/workspace",
   "version": "0.0.1",
   "private": true,
+  "main": "./src/index.ts",
   "dependencies": {
     "@nx/devkit": "20.3.2"
   },

--- a/projects/workspace/src/index.ts
+++ b/projects/workspace/src/index.ts
@@ -1,0 +1,1 @@
+export * from './plugins/typecheck/index.js';

--- a/projects/workspace/src/plugins/typecheck/index.ts
+++ b/projects/workspace/src/plugins/typecheck/index.ts
@@ -1,0 +1,65 @@
+import { basename } from 'node:path';
+import {
+  CreateNodesContextV2,
+  CreateNodesResult,
+  CreateNodesV2,
+  TargetConfiguration,
+  createNodesFromFiles,
+} from '@nx/devkit';
+
+/**
+ * Determines the correct tsconfig file to use based on project type.
+ * - Applications (in projects/apps/) should use tsconfig.app.json
+ * - Libraries (in projects/libs/) should use tsconfig.lib.json
+ */
+const findTsconfig = (configFilePath: string) => {
+  const filename = basename(configFilePath);
+  return filename;
+};
+
+function buildTypecheckTarget(
+  configFilePath: string,
+  _options: unknown,
+  _context: CreateNodesContextV2,
+): CreateNodesResult {
+  const projectRoot = configFilePath.split('/').slice(0, -1).join('/');
+
+  const tsconfig = findTsconfig(configFilePath);
+
+  if (!tsconfig) return {};
+
+  const target: TargetConfiguration = {
+    executor: 'nx:run-commands',
+    cache: true,
+    inputs: ['default', '^default', 'plugins'],
+    outputs: [], // absolutely no files written
+    options: {
+      cwd: `{projectRoot}`,
+      command: `tsc -p ${tsconfig} --noEmit`,
+      parallel: false,
+      color: true,
+    },
+  };
+
+  return {
+    projects: {
+      [projectRoot]: {
+        targets: {
+          typecheck: target,
+        },
+      },
+    },
+  };
+}
+
+export const createNodesV2: CreateNodesV2 = [
+  // Only match tsconfig.app.json and tsconfig.lib.json to avoid duplicate targets
+  '**/{tsconfig.app.json,tsconfig.lib.json}',
+  async (configFilePaths, options, context) => {
+    return await createNodesFromFiles(buildTypecheckTarget, configFilePaths, options, context);
+  },
+];
+
+export const createNodes = createNodesV2;
+
+export default createNodesV2;


### PR DESCRIPTION
# feat(kill-process): add battery consumption sorting with automated sudo setup

## The Reason

Users need visibility into which processes are draining battery on macOS to identify and terminate energy-intensive applications. CPU and memory metrics alone don't reveal the full picture of resource consumption.

### The problem

macOS `powermetrics` command requires root privileges and prompts for password, which interrupts Alfred's workflow and closes the search box. Without automated setup, users would need manual sudoers configuration or face repeated password prompts.

## The Solution

Implemented battery sorting using macOS `powermetrics` with automated passwordless sudo configuration:

1. **New `!b` keyword** - Sorts processes by energy impact (highest first)
2. **Automated sudo setup** - First-time use creates `/etc/sudoers.d/powermetrics` rule for passwordless execution (one-time password prompt via fingerprint)
3. **Smart data fetching** - Battery metrics only collected when sorting by battery (no performance impact on other modes)
4. **Proper sampling interval** - Uses 2.5 second interval (`-i 2500`) for accurate energy measurements per powermetrics documentation
5. **Zod validation** - Runtime type safety for battery data results
6. **Error handling** - Gracefully handles sudo failures, command timeouts, and missing data with user-friendly error messages


This improves user experience by providing instant access to battery consumption data without manual configuration or workflow interruptions, enabling users to quickly identify and terminate battery-draining processes.
