### PR TITLE
feat(timezones): support time zones detection and extraction

### DIFF
--- a/projects/packages/ai-calendar-assistant/.fast-alfred.config.cjs
+++ b/projects/packages/ai-calendar-assistant/.fast-alfred.config.cjs
@@ -20,6 +20,8 @@ This workflow has been created using Fast Alfred, a user-friendly workflow build
 2. Enter the event details in natural language (e.g., "Meeting with John next Friday at 2pm for like 2-3 hours").
 3. Press Enter to create the event in your calendar.
 
+Hold \`⌘\` and press \`Enter\` on any result to preview the parsed event in Large Type before creating it.
+
 To view the workflow codebase, click here:
 ${homepage}
 `.trim();

--- a/projects/packages/ai-calendar-assistant/README.md
+++ b/projects/packages/ai-calendar-assistant/README.md
@@ -23,6 +23,8 @@ Effortlessly create calendar events using natural language. This workflow intell
 1. Enter the event details in natural language (e.g., "Meeting with John next Friday at 2pm for like 2-3 hours").
 1. Press Enter to create the event in your calendar.
 
+Hold `⌘` and press `Enter` on any result to preview the parsed event in Large Type before creating it.
+
 ## Demo
 
 ### Relative Time

--- a/projects/packages/ai-calendar-assistant/info.plist
+++ b/projects/packages/ai-calendar-assistant/info.plist
@@ -10,6 +10,16 @@
       <array>
         <dict>
           <key>modifiers</key>
+          <integer>1048576</integer>
+          <key>modifiersubtext</key>
+          <string>Preview</string>
+          <key>vitoclose</key>
+          <true></true>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+        </dict>
+        <dict>
+          <key>modifiers</key>
           <integer>0</integer>
           <key>modifiersubtext</key>
           <string></string>
@@ -17,6 +27,43 @@
           <true></true>
           <key>destinationuid</key>
           <string>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_A3359AE8-545E-446B-84EC-E556466D8850</string>
+        </dict>
+      </array>
+      <key>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</key>
+      <array>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <true></true>
+          <key>destinationuid</key>
+          <string>3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+        </dict>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>sourceoutputuid</key>
+          <string>__fast-alfred_managed__v2_condition_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_updater_workflow-update</string>
+        </dict>
+        <dict>
+          <key>modifiers</key>
+          <integer>0</integer>
+          <key>modifiersubtext</key>
+          <string></string>
+          <key>vitoclose</key>
+          <false></false>
+          <key>sourceoutputuid</key>
+          <string>__fast-alfred_managed__v2_condition_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+          <key>destinationuid</key>
+          <string>__fast-alfred_managed__v2_updater_snooze</string>
         </dict>
       </array>
       <key>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_A3359AE8-545E-446B-84EC-E556466D8850</key>
@@ -140,6 +187,35 @@
         <integer>2</integer>
       </dict>
       <dict>
+        <key>config</key>
+        <dict>
+          <key>alignment</key>
+          <integer>0</integer>
+          <key>backgroundcolor</key>
+          <string></string>
+          <key>fadespeed</key>
+          <integer>0</integer>
+          <key>fillmode</key>
+          <integer>0</integer>
+          <key>font</key>
+          <string></string>
+          <key>ignoredynamicplaceholders</key>
+          <false></false>
+          <key>largetypetext</key>
+          <string>{query}</string>
+          <key>textcolor</key>
+          <string></string>
+          <key>wrapat</key>
+          <integer>50</integer>
+        </dict>
+        <key>type</key>
+        <string>alfred.workflow.output.largetype</string>
+        <key>uid</key>
+        <string>3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+        <key>version</key>
+        <integer>3</integer>
+      </dict>
+      <dict>
         <key>type</key>
         <string>alfred.workflow.action.script</string>
         <key>uid</key>
@@ -183,6 +259,38 @@
           <string></string>
           <key>type</key>
           <integer>11</integer>
+        </dict>
+      </dict>
+      <dict>
+        <key>type</key>
+        <string>alfred.workflow.utility.conditional</string>
+        <key>uid</key>
+        <string>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+        <key>version</key>
+        <integer>1</integer>
+        <key>config</key>
+        <dict>
+          <key>conditions</key>
+          <array>
+            <dict>
+              <key>inputstring</key>
+              <string>{query}</string>
+              <key>matchcasesensitive</key>
+              <false></false>
+              <key>matchmode</key>
+              <integer>4</integer>
+              <key>matchstring</key>
+              <string>__fast-alfred_managed__</string>
+              <key>outputlabel</key>
+              <string>Managed versions updates</string>
+              <key>uid</key>
+              <string>__fast-alfred_managed__v2_condition_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</string>
+            </dict>
+          </array>
+          <key>elselabel</key>
+          <string>Default Behavior</string>
+          <key>hideelse</key>
+          <false></false>
         </dict>
       </dict>
       <dict>
@@ -236,6 +344,8 @@ This workflow has been created using Fast Alfred, a user-friendly workflow build
 2. Enter the event details in natural language (e.g., "Meeting with John next Friday at 2pm for like 2-3 hours").
 3. Press Enter to create the event in your calendar.
 
+Hold `⌘` and press `Enter` on any result to preview the parsed event in Large Type before creating it.
+
 To view the workflow codebase, click here:
 https://github.com/Avivbens/alfredo</string>
     <key>uidata</key>
@@ -253,6 +363,13 @@ https://github.com/Avivbens/alfredo</string>
         <integer>505</integer>
         <key>ypos</key>
         <integer>345</integer>
+      </dict>
+      <key>3CABA990-1C42-4A89-97EE-4FA184C92BB6</key>
+      <dict>
+        <key>xpos</key>
+        <integer>505</integer>
+        <key>ypos</key>
+        <integer>555</integer>
       </dict>
       <key>__fast-alfred_managed__v2_updater_workflow-update</key>
       <dict>
@@ -272,12 +389,21 @@ https://github.com/Avivbens/alfredo</string>
         <key>note</key>
         <string>Snooze Updates Helper</string>
       </dict>
-      <key>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_A3359AE8-545E-446B-84EC-E556466D8850</key>
+      <key>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_3CABA990-1C42-4A89-97EE-4FA184C92BB6</key>
       <dict>
         <key>xpos</key>
         <integer>295</integer>
         <key>ypos</key>
         <integer>345</integer>
+        <key>note</key>
+        <string>Conditional Updates Helper</string>
+      </dict>
+      <key>__fast-alfred_managed__v2_conditional_from_25207757-A5EF-4D58-9006-05FC11CBBF2E_to_A3359AE8-545E-446B-84EC-E556466D8850</key>
+      <dict>
+        <key>xpos</key>
+        <integer>295</integer>
+        <key>ypos</key>
+        <integer>565</integer>
         <key>note</key>
         <string>Conditional Updates Helper</string>
       </dict>

--- a/projects/packages/ai-calendar-assistant/src/common/prompts/extract-event-name.prompt.ts
+++ b/projects/packages/ai-calendar-assistant/src/common/prompts/extract-event-name.prompt.ts
@@ -1,15 +1,25 @@
 import { PromptTemplate } from '@langchain/core/prompts';
 
 export const EXTRACT_EVENT_SYSTEM_PROMPT = new PromptTemplate({
-  inputVariables: ['currentDate'],
+  inputVariables: ['currentDate', 'currentTimezone'],
   template: `You are an AI assistant that extracts calendar event details from text.
 Your task is to analyze the user's input and generate a list of events.
 Pay close attention to the context to determine the correct date and time, especially for relative dates like "next Monday" or "tomorrow".
 When multiple events are mentioned, make sure to associate details like location and description with the correct event.
 The current date is: {currentDate}. Use this for relative dates.
+The user's current timezone is: {currentTimezone}.
 If no end time is specified, assume a 1-hour duration.
 If an event spans multiple days and no specific time is mentioned, provide just the dates for startDate and endDate.
 If a general time of day is mentioned (e.g., 'morning', 'afternoon', 'evening'), use a reasonable time (e.g., 9am for morning, 3pm for afternoon, 7pm for evening).
+
+Timezone handling — follow this decision procedure for every event:
+1. Identify the event's location (a city, country, region, or named timezone). The location may come from words like "in", "at", "while in", "from", or simply a city/country mentioned next to the event.
+2. Map that location to its IANA timezone (e.g., Madrid → "Europe/Madrid", Tokyo → "Asia/Tokyo", NYC → "America/New_York", London → "Europe/London", Sydney → "Australia/Sydney"). Use your knowledge of geography to do this — do NOT skip this step just because the user didn't spell out the IANA name.
+3. Compare that timezone to the user's current timezone ({currentTimezone}).
+   - If they DIFFER: set the timeZone field to the event's IANA name AND write startDate/endDate as the local wall-clock time at the event's location WITH the matching UTC offset embedded (e.g., "2025-07-07T15:00:00-04:00"). Do not convert into the user's local time.
+   - If they MATCH (or no location was given): OMIT the timeZone field and write dates without an offset (e.g., "2025-06-30T15:00:00").
+4. When in doubt about whether a city's timezone differs from {currentTimezone}, set timeZone — extra accuracy is preferred over missing it.
+
 Your response must be ONLY the list of events.
 
 ---
@@ -53,10 +63,31 @@ summary: Meet with Angela
 startDate: 2025-07-07
 endDate: 2025-07-09
 location: Japan
+timeZone: "Asia/Tokyo"
 
 Event 2:
 summary: Buy a suitcase
 startDate: 2025-07-06T12:00:00
 endDate: 2025-07-06T13:00:00
+
+---
+Input: "Lunch with Sarah in NYC next Friday at 1pm"
+Expected key-values:
+Event 1:
+summary: "Lunch with Sarah"
+startDate: "2025-07-04T13:00:00-04:00"
+endDate: "2025-07-04T14:00:00-04:00"
+location: NYC
+timeZone: "America/New_York"
+
+---
+Input: "Conference in Madrid, Spain on July 10 at 9am"
+Expected key-values:
+Event 1:
+summary: "Conference"
+startDate: "2025-07-10T09:00:00+02:00"
+endDate: "2025-07-10T10:00:00+02:00"
+location: "Madrid, Spain"
+timeZone: "Europe/Madrid"
 `,
 });

--- a/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
+++ b/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
@@ -4,7 +4,7 @@ import { AvailableModelsSchema } from '@alfredo/llm';
 import { registerUpdater } from '@alfredo/updater';
 import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { Variables } from '../common/variables.enum';
-import { beautifyDate, dropTimezone } from '../services/date.service';
+import { beautifyDate, dateInTimezoneAsLocal, getCurrentTimezone } from '../services/date.service';
 import { extractEvent } from '../services/event-extractor.service';
 
 (async () => {
@@ -43,11 +43,25 @@ import { extractEvent } from '../services/event-extractor.service';
       return;
     }
 
+    const machineTimezone = getCurrentTimezone();
     const items: AlfredListItem[] = events.map((currEvent) => {
-      const { allDayEvent, endDate, startDate, summary, description, location, url } = currEvent;
+      const { allDayEvent, endDate, startDate, summary, description, location, url, timeZone } = currEvent;
 
       const title = `${summary}${location ? ` | at ${location}` : ''}${url ? ` (${url})` : ''}`;
-      const subtitle = `${allDayEvent ? 'All-day event' : `From ${beautifyDate(dropTimezone(startDate))} to ${beautifyDate(dropTimezone(endDate))}`} | ${description || 'No description'}`;
+
+      /**
+       * Render the subtitle using the event's wall-clock at its IANA timezone
+       * so the time matches what the user typed. When the event is in a
+       * different zone than the machine, append a short label (the city part
+       * of the IANA name) so the user knows the time is at-location.
+       */
+      const eventTimezone = timeZone ?? machineTimezone;
+      const isLocal = eventTimezone === machineTimezone;
+      const tzLabel = isLocal ? '' : ` (${eventTimezone.split('/').pop()?.replace(/_/g, ' ') ?? eventTimezone})`;
+      const startDisplay = dateInTimezoneAsLocal(startDate, eventTimezone);
+      const endDisplay = dateInTimezoneAsLocal(endDate, eventTimezone);
+      const timeRange = `From ${beautifyDate(startDisplay)} to ${beautifyDate(endDisplay)}${tzLabel}`;
+      const subtitle = `${allDayEvent ? 'All-day event' : timeRange} | ${description || 'No description'}`;
       const arg = JSON.stringify(currEvent);
       const uid = `${startDate}-${summary}`;
 

--- a/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
+++ b/projects/packages/ai-calendar-assistant/src/main/extract-event.ts
@@ -6,6 +6,7 @@ import { DEFAULT_DEBOUNCE_TIME } from '../common/defaults.constants';
 import { Variables } from '../common/variables.enum';
 import { beautifyDate, dateInTimezoneAsLocal, getCurrentTimezone } from '../services/date.service';
 import { extractEvent } from '../services/event-extractor.service';
+import { buildEventPreview } from '../services/event-preview.service';
 
 (async () => {
   const alfredClient = new FastAlfred();
@@ -70,6 +71,12 @@ import { extractEvent } from '../services/event-extractor.service';
         uid,
         subtitle,
         arg,
+        mods: {
+          cmd: {
+            subtitle: 'Preview',
+            arg: buildEventPreview(currEvent, machineTimezone),
+          },
+        },
       };
     });
 

--- a/projects/packages/ai-calendar-assistant/src/models/calendar-event.model.ts
+++ b/projects/packages/ai-calendar-assistant/src/models/calendar-event.model.ts
@@ -13,6 +13,11 @@ const location = z.string().describe('The location of the event, if mentioned.')
 const description = z.string().describe('Any additional details or notes about the event.');
 const url = z.string().describe('A URL for the event, if provided.');
 const allDayEvent = z.boolean().describe('Set to true if the event is for the whole day, otherwise false.');
+const timeZone = z
+  .string()
+  .describe(
+    'IANA timezone name for the event (e.g., "America/New_York", "Europe/London", "Asia/Tokyo"). Set this only when the event takes place in a timezone different from the user\'s current one — typically inferred from the location. Omit otherwise; the user\'s current timezone will be used.',
+  );
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
@@ -24,6 +29,7 @@ type CalendarEventTransformInput = {
   description?: string | null;
   url?: string | null;
   allDayEvent?: boolean | null;
+  timeZone?: string | null;
 };
 
 const eventTransform = (data: CalendarEventTransformInput) => {
@@ -57,11 +63,18 @@ const eventTransform = (data: CalendarEventTransformInput) => {
     }
   }
 
+  const { timeZone, ...rest } = data;
+
   return {
-    ...data,
+    ...rest,
     startDate,
     endDate,
     allDayEvent,
+    /**
+     * Normalize away the OpenAI-schema `null` so downstream consumers only
+     * see `string | undefined`.
+     */
+    ...(timeZone ? { timeZone } : {}),
   };
 };
 
@@ -75,6 +88,7 @@ export const OpenAICalendarEventSchema = z
     description: description.optional().nullable(),
     url: url.optional().nullable(),
     allDayEvent: allDayEvent.optional().nullable().default(false),
+    timeZone: timeZone.optional().nullable(),
   })
   .transform(eventTransform);
 
@@ -90,6 +104,7 @@ export const GeminiCalendarEventSchema = z
     description: description.optional(),
     url: url.optional(),
     allDayEvent: allDayEvent.optional().default(false),
+    timeZone: timeZone.optional(),
   })
   .transform(eventTransform);
 

--- a/projects/packages/ai-calendar-assistant/src/services/date.service.spec.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/date.service.spec.ts
@@ -1,9 +1,10 @@
 import {
   beautifyDate,
+  dateInTimezoneAsLocal,
   dateTimezoneNatural,
-  dropTimezone,
   formatDateToAppleScript,
   formatGoogleDate,
+  getCurrentTimezone,
 } from './date.service';
 
 describe('date.service', () => {
@@ -51,16 +52,41 @@ describe('date.service', () => {
       const expected = formatGoogleDate(utcDate, false);
       expect(formatGoogleDate(date, false)).toBe(expected);
     });
+
+    it('should format the date in the provided timezone', () => {
+      const date = new Date('2025-07-15T19:00:00Z');
+      // 19:00 UTC = 15:00 in America/New_York (EDT, -04:00)
+      expect(formatGoogleDate(date, false, 'America/New_York')).toBe('20250715T150000');
+    });
   });
 
-  describe('dropTimezone', () => {
-    it('should remove the timezone offset correctly', () => {
-      const localDate = new Date();
-      const droppedDate = dropTimezone(localDate);
-      // The expected date should be the local time, but interpreted as UTC.
-      // This is achieved by adding the timezone offset to the UTC time.
-      const expectedDate = new Date(localDate.getTime() + localDate.getTimezoneOffset() * 60000);
-      expect(droppedDate.toISOString()).toBe(expectedDate.toISOString());
+  describe('getCurrentTimezone', () => {
+    it('should return a non-empty IANA timezone string', () => {
+      const tz = getCurrentTimezone();
+      expect(typeof tz).toBe('string');
+      expect(tz.length).toBeGreaterThan(0);
+      expect(tz).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    });
+  });
+
+  describe('dateInTimezoneAsLocal', () => {
+    it('should produce a Date whose local wall-clock matches the wall-clock at the given IANA timezone', () => {
+      // 11:15 UTC = 13:15 in Europe/Madrid (CEST, UTC+2)
+      const date = new Date('2026-05-10T11:15:00Z');
+      const result = dateInTimezoneAsLocal(date, 'Europe/Madrid');
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(4);
+      expect(result.getDate()).toBe(10);
+      expect(result.getHours()).toBe(13);
+      expect(result.getMinutes()).toBe(15);
+    });
+
+    it('should reflect different timezones for the same absolute moment', () => {
+      const date = new Date('2026-05-10T11:15:00Z');
+      // 11:15 UTC = 19:15 in Asia/Makassar (UTC+8)
+      const result = dateInTimezoneAsLocal(date, 'Asia/Makassar');
+      expect(result.getHours()).toBe(19);
+      expect(result.getMinutes()).toBe(15);
     });
   });
 

--- a/projects/packages/ai-calendar-assistant/src/services/date.service.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/date.service.ts
@@ -6,12 +6,12 @@ export function formatDateToAppleScript(date: Date): string {
   return `date "${day} ${month} ${year} ${time}"`;
 }
 
-export function formatGoogleDate(date: Date, allDay: boolean): string {
+export function formatGoogleDate(date: Date, allDay: boolean, timeZone = 'UTC'): string {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-    timeZone: 'UTC',
+    timeZone,
   };
 
   if (!allDay) {
@@ -39,11 +39,42 @@ export function formatGoogleDate(date: Date, allDay: boolean): string {
   return `${year}${month}${day}T${hour}${minute}${second}`;
 }
 
-export function dropTimezone(date: Date): Date {
-  const timezoneOffset = new Date().getTimezoneOffset() / -60;
-  const adjustedDate = new Date(date);
-  adjustedDate.setHours(adjustedDate.getHours() - timezoneOffset);
-  return adjustedDate;
+export function getCurrentTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/**
+ * Build a "floating" Date whose machine-local wall-clock equals the absolute
+ * moment's wall-clock at the given IANA timezone. Used for display surfaces
+ * (Alfred subtitle, etc.) that read local Date methods — feeding them this
+ * Date makes them render the event's location wall-clock.
+ *
+ * For events in the user's machine timezone this is effectively a re-parse,
+ * since the wall-clock at the machine timezone is already what local methods
+ * would return.
+ */
+export function dateInTimezoneAsLocal(date: Date, timeZone: string = getCurrentTimezone()): Date {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value ?? '0';
+
+  return new Date(
+    Number(get('year')),
+    Number(get('month')) - 1,
+    Number(get('day')),
+    Number(get('hour')),
+    Number(get('minute')),
+    Number(get('second')),
+  );
 }
 
 export function dateTimezoneNatural(date: Date): string {

--- a/projects/packages/ai-calendar-assistant/src/services/event-creator.service.spec.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/event-creator.service.spec.ts
@@ -17,9 +17,9 @@ jest.mock('@alfredo/run-applescript', () => ({
 }));
 
 // Spy on dateService functions
-jest.spyOn(dateService, 'dropTimezone');
 jest.spyOn(dateService, 'formatDateToAppleScript');
 jest.spyOn(dateService, 'formatGoogleDate');
+jest.spyOn(dateService, 'getCurrentTimezone').mockReturnValue('Asia/Jerusalem');
 
 describe('event-creator.service', () => {
   const calendarName = 'Test Calendar';
@@ -41,8 +41,8 @@ describe('event-creator.service', () => {
   describe('eventCreatorAppleScript', () => {
     it('should generate a valid AppleScript for a basic event without opening', () => {
       const script = eventCreatorAppleScript(calendarName, baseEvent, false);
-      expect(dateService.formatDateToAppleScript).toHaveBeenCalledTimes(2);
-      expect(dateService.dropTimezone).toHaveBeenCalledTimes(2);
+      expect(dateService.formatDateToAppleScript).toHaveBeenCalledWith(baseEvent.startDate);
+      expect(dateService.formatDateToAppleScript).toHaveBeenCalledWith(baseEvent.endDate);
       expect(script).toContain(`tell application "Calendar"`);
       expect(script).toContain(`tell calendar "${calendarName}"`);
       expect(script).toContain(`summary:"Test Event"`);
@@ -91,17 +91,57 @@ describe('event-creator.service', () => {
       expect(script).not.toContain(`description:""`);
       expect(script).not.toContain(`url:""`);
     });
+
+    it('should append timezone to the description when it differs from the machine timezone', () => {
+      const tzEvent: CalendarEvent = {
+        ...baseEvent,
+        description: 'Original notes.',
+        timeZone: 'Europe/Madrid',
+      };
+      const script = eventCreatorAppleScript(calendarName, tzEvent, false);
+      expect(script).toContain(`description:"Original notes.\\n\\nTimezone: Europe/Madrid"`);
+    });
+
+    it('should add a timezone-only description when no other description is set', () => {
+      const tzEvent: CalendarEvent = { ...baseEvent, timeZone: 'Europe/Madrid' };
+      const script = eventCreatorAppleScript(calendarName, tzEvent, false);
+      expect(script).toContain(`description:"Timezone: Europe/Madrid"`);
+    });
+
+    it('should NOT append timezone when it matches the machine timezone', () => {
+      const tzEvent: CalendarEvent = { ...baseEvent, timeZone: 'Asia/Jerusalem' };
+      const script = eventCreatorAppleScript(calendarName, tzEvent, false);
+      expect(script).not.toContain('Timezone:');
+    });
+
+    it('should pass start/end dates straight to formatDateToAppleScript regardless of timezone', () => {
+      const tzEvent: CalendarEvent = { ...baseEvent, timeZone: 'Europe/Madrid' };
+      eventCreatorAppleScript(calendarName, tzEvent, false);
+      expect(dateService.formatDateToAppleScript).toHaveBeenCalledWith(tzEvent.startDate);
+      expect(dateService.formatDateToAppleScript).toHaveBeenCalledWith(tzEvent.endDate);
+    });
   });
 
   describe('eventCreatorGoogleCalendar', () => {
     it('should generate and open a valid Google Calendar URL', async () => {
       await eventCreatorGoogleCalendar(baseEvent);
-      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(baseEvent.startDate, false);
-      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(baseEvent.endDate, false);
+      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(baseEvent.startDate, false, undefined);
+      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(baseEvent.endDate, false, undefined);
       expect(zurk.$).toHaveBeenCalledWith({ nothrow: true });
       expect(zurkTemplateLiteralFn).toHaveBeenCalledWith(
         expect.arrayContaining([expect.stringContaining('open ')]),
         expect.stringContaining('https://calendar.google.com/calendar/render'),
+      );
+    });
+
+    it('should pass the event timeZone to formatGoogleDate and include ctz in the URL', async () => {
+      const eventWithTz: CalendarEvent = { ...baseEvent, timeZone: 'America/New_York' };
+      await eventCreatorGoogleCalendar(eventWithTz);
+      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(eventWithTz.startDate, false, 'America/New_York');
+      expect(dateService.formatGoogleDate).toHaveBeenCalledWith(eventWithTz.endDate, false, 'America/New_York');
+      expect(zurkTemplateLiteralFn).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.stringContaining('ctz=America%2FNew_York'),
       );
     });
 

--- a/projects/packages/ai-calendar-assistant/src/services/event-creator.service.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/event-creator.service.ts
@@ -2,26 +2,45 @@ import { $ } from 'zurk';
 import { runAppleScript } from '@alfredo/run-applescript';
 import { CalendarEvent } from '../models/calendar-event.model';
 import { OpenEventPlatform } from '../models/open-event-platform.enum';
-import { dropTimezone, formatDateToAppleScript, formatGoogleDate } from './date.service';
+import { formatDateToAppleScript, formatGoogleDate, getCurrentTimezone } from './date.service';
 
 export const eventCreatorAppleScript = (calendarName: string, event: CalendarEvent, shouldOpen: boolean): string => {
-  const { summary, startDate, endDate, location, description, url, allDayEvent } = event;
+  const { summary, startDate, endDate, location, description, url, allDayEvent, timeZone } = event;
 
+  /**
+   * AppleScript Calendar events are floating — there's no settable `time zone`
+   * property — so we cannot tag the event with its IANA timezone. To keep the
+   * absolute moment correct (the event fires when it should), we hand AppleScript
+   * the user's machine-local wall-clock of the same UTC moment. For non-local
+   * events the description carries a `Timezone: …` hint so the user still knows
+   * which timezone the event is anchored to.
+   */
   const properties = [
     /*  */
     `summary:"${summary}"`,
-    `start date:${formatDateToAppleScript(dropTimezone(startDate))}`,
-    `end date:${formatDateToAppleScript(dropTimezone(endDate))}`,
+    `start date:${formatDateToAppleScript(startDate)}`,
+    `end date:${formatDateToAppleScript(endDate)}`,
   ];
 
   /**
-   * Optional properties for the event
+   * Optional properties for the event.
+   *
+   * Apple Calendar's AppleScript dictionary does not expose a settable `time zone`
+   * property on events (events are floating). To still surface the timezone to the
+   * user, we append it to the description when it differs from undefined.
    */
   if (location) {
     properties.push(`location:"${location}"`);
   }
+  const descriptionParts: string[] = [];
   if (description) {
-    properties.push(`description:"${description}"`);
+    descriptionParts.push(description);
+  }
+  if (timeZone && timeZone !== getCurrentTimezone()) {
+    descriptionParts.push(`Timezone: ${timeZone}`);
+  }
+  if (descriptionParts.length > 0) {
+    properties.push(`description:"${descriptionParts.join('\\n\\n')}"`);
   }
   if (url) {
     properties.push(`url:"${url}"`);
@@ -41,14 +60,23 @@ end tell
 };
 
 export async function eventCreatorGoogleCalendar(event: CalendarEvent): Promise<void> {
-  const { summary, startDate, endDate, description, location, allDayEvent } = event;
+  const { summary, startDate, endDate, description, location, allDayEvent, timeZone } = event;
   const url = new URL('https://calendar.google.com/calendar/render');
   url.searchParams.set('action', 'TEMPLATE');
   url.searchParams.set('text', summary);
 
-  const formattedStartDate = formatGoogleDate(startDate, allDayEvent);
-  const formattedEndDate = formatGoogleDate(endDate, allDayEvent);
+  const formattedStartDate = formatGoogleDate(startDate, allDayEvent, timeZone);
+  const formattedEndDate = formatGoogleDate(endDate, allDayEvent, timeZone);
   url.searchParams.set('dates', `${formattedStartDate}/${formattedEndDate}`);
+
+  if (timeZone) {
+    /**
+     * `ctz` makes Google Calendar interpret the wall-clock dates above in this
+     * timezone, so events placed in a different country render correctly
+     * regardless of the viewer's browser locale.
+     */
+    url.searchParams.set('ctz', timeZone);
+  }
 
   if (description) {
     url.searchParams.set('details', description);

--- a/projects/packages/ai-calendar-assistant/src/services/event-extractor.service.spec.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/event-extractor.service.spec.ts
@@ -1,7 +1,7 @@
 import { callModelWithStructuredResponse } from '@alfredo/llm';
 import { EXTRACT_EVENT_SYSTEM_PROMPT } from '../common/prompts/extract-event-name.prompt';
 import { GeminiCalendarEventsSchema } from '../models/calendar-event.model';
-import { dateTimezoneNatural } from './date.service';
+import { dateTimezoneNatural, getCurrentTimezone } from './date.service';
 import { extractEvent } from './event-extractor.service';
 
 const { AvailableModels } = jest.requireActual('@alfredo/llm');
@@ -14,6 +14,7 @@ jest.mock('@alfredo/llm', () => ({
 // Mock the date service
 jest.mock('./date.service', () => ({
   dateTimezoneNatural: jest.fn(() => '2025-01-01T12:00:00'),
+  getCurrentTimezone: jest.fn(() => 'Asia/Jerusalem'),
 }));
 
 // Mock the prompt
@@ -33,28 +34,54 @@ describe('extractEvent', () => {
   });
 
   it('should call the LLM with the correct parameters and return the events', async () => {
-    const mockEvents = [
-      {
-        summary: 'Test Event',
-        startDate: new Date('2025-01-01T10:00:00.000Z'),
-        endDate: new Date('2025-01-01T11:00:00.000Z'),
-        allDayEvent: false,
-      },
-    ];
+    const mockEvents = {
+      events: [
+        {
+          summary: 'Test Event',
+          startDate: new Date('2025-01-01T10:00:00.000Z'),
+          endDate: new Date('2025-01-01T11:00:00.000Z'),
+          allDayEvent: false,
+        },
+      ],
+    };
 
     (callModelWithStructuredResponse as jest.Mock).mockResolvedValue(mockEvents);
 
-    const events = await extractEvent(token, model, input);
+    const result = await extractEvent(token, model, input);
 
     expect(dateTimezoneNatural).toHaveBeenCalledWith(expect.any(Date));
-    expect(EXTRACT_EVENT_SYSTEM_PROMPT.format).toHaveBeenCalledWith({ currentDate: '2025-01-01T12:00:00' });
+    expect(getCurrentTimezone).toHaveBeenCalled();
+    expect(EXTRACT_EVENT_SYSTEM_PROMPT.format).toHaveBeenCalledWith({
+      currentDate: '2025-01-01T12:00:00',
+      currentTimezone: 'Asia/Jerusalem',
+    });
     expect(callModelWithStructuredResponse).toHaveBeenCalledWith(
       token,
       model,
       { system: 'Formatted Prompt', user: input },
       GeminiCalendarEventsSchema,
     );
-    expect(events).toEqual(mockEvents);
+    expect(result.events[0]).toEqual({ ...mockEvents.events[0], timeZone: 'Asia/Jerusalem' });
+  });
+
+  it('should preserve a model-provided timeZone instead of overriding it', async () => {
+    const mockEvents = {
+      events: [
+        {
+          summary: 'NYC trip',
+          startDate: new Date('2025-07-04T17:00:00.000Z'),
+          endDate: new Date('2025-07-04T18:00:00.000Z'),
+          allDayEvent: false,
+          timeZone: 'America/New_York',
+        },
+      ],
+    };
+
+    (callModelWithStructuredResponse as jest.Mock).mockResolvedValue(mockEvents);
+
+    const result = await extractEvent(token, model, input);
+
+    expect(result.events[0]?.timeZone).toBe('America/New_York');
   });
 
   it('should handle errors from the LLM call', async () => {

--- a/projects/packages/ai-calendar-assistant/src/services/event-extractor.service.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/event-extractor.service.ts
@@ -1,7 +1,7 @@
 import { AvailableModels, callModelWithStructuredResponse } from '@alfredo/llm';
 import { EXTRACT_EVENT_SYSTEM_PROMPT } from '../common/prompts/extract-event-name.prompt';
 import { CalendarEvents, GeminiCalendarEventsSchema, OpenAICalendarEventsSchema } from '../models/calendar-event.model';
-import { dateTimezoneNatural } from './date.service';
+import { dateTimezoneNatural, getCurrentTimezone } from './date.service';
 
 export async function extractEvent(token: string, model: AvailableModels, input: string): Promise<CalendarEvents> {
   /**
@@ -9,10 +9,17 @@ export async function extractEvent(token: string, model: AvailableModels, input:
    */
   const calendarEventsSchema = model.includes('gemini') ? GeminiCalendarEventsSchema : OpenAICalendarEventsSchema;
 
+  const currentTimezone = getCurrentTimezone();
   const currentDate = dateTimezoneNatural(new Date());
-  const system = await EXTRACT_EVENT_SYSTEM_PROMPT.format({ currentDate });
+  const system = await EXTRACT_EVENT_SYSTEM_PROMPT.format({ currentDate, currentTimezone });
 
-  const events = await callModelWithStructuredResponse(token, model, { system, user: input }, calendarEventsSchema);
+  const { events } = await callModelWithStructuredResponse(token, model, { system, user: input }, calendarEventsSchema);
 
-  return events;
+  /**
+   * Default each event's timeZone to the user's current timezone when the
+   * model didn't surface a different one.
+   */
+  return {
+    events: events.map((event) => ({ ...event, timeZone: event.timeZone ?? currentTimezone })),
+  };
 }

--- a/projects/packages/ai-calendar-assistant/src/services/event-preview.service.ts
+++ b/projects/packages/ai-calendar-assistant/src/services/event-preview.service.ts
@@ -1,0 +1,30 @@
+import { CalendarEvent } from '../models/calendar-event.model';
+import { beautifyDate, dateInTimezoneAsLocal, getCurrentTimezone } from './date.service';
+
+/**
+ * Build a multi-line, human-readable description of a parsed calendar event
+ * for Alfred's Large Type preview (cmd+Enter). Lines for missing fields are
+ * omitted so the card stays tight. Time strings use the event's IANA timezone
+ * so they match what the user typed and what the in-list subtitle shows.
+ */
+export function buildEventPreview(event: CalendarEvent, machineTimezone: string = getCurrentTimezone()): string {
+  const { allDayEvent, endDate, startDate, summary, description, location, url, timeZone } = event;
+
+  const eventTimezone = timeZone ?? machineTimezone;
+  const isLocal = eventTimezone === machineTimezone;
+  const tzLabel = isLocal ? '' : ` (${eventTimezone.split('/').pop()?.replace(/_/g, ' ') ?? eventTimezone})`;
+  const startDisplay = dateInTimezoneAsLocal(startDate, eventTimezone);
+  const endDisplay = dateInTimezoneAsLocal(endDate, eventTimezone);
+  const whenLine = allDayEvent
+    ? 'All-day event'
+    : `From ${beautifyDate(startDisplay)} to ${beautifyDate(endDisplay)}${tzLabel}`;
+
+  const detailLines = [
+    `When: ${whenLine}`,
+    location ? `Where: ${location}` : null,
+    url ? `Link: ${url}` : null,
+    !isLocal ? `Timezone: ${eventTimezone}` : null,
+  ].filter((line): line is string => line !== null);
+
+  return [summary, '', ...detailLines, ...(description ? ['', description] : [])].join('\n');
+}


### PR DESCRIPTION
## The Reason

The AI Calendar Assistant treated every event as if it took place in the user's machine timezone. The model was given a "natural" (timezone-less) current date and returned wall-clock times that were silently parsed as machine-local — events typed for a different country ended up at the wrong absolute moment, and the user had no way to express "this event is in another timezone".

### The problem

Three concrete failures stacked on top of each other:

1. **No timezone in the schema.** The model could not surface a timezone for events that took place elsewhere (e.g. _"wedding in Madrid at 14:00"_), so the absolute moment was always interpreted as machine-local. A Madrid 14:00 event from Asia/Makassar landed at 14:00 Bali absolute, not 14:00 Madrid.

2. **`dropTimezone` was mathematically wrong.** It did `setHours(getHours() - timezoneOffset)`, which subtracted the offset on top of a Date that already represented the correct absolute moment. The effect was a `2 × offset` shift on display — for the boat-trip booking with `13:15 WITA` from Asia/Makassar (UTC+8), the Alfred subtitle showed `5:15`. `formatDateToAppleScript` and `beautifyDate` already use local methods, which return the right wall-clock without any "adjustment".

3. **Apple Calendar has no settable timezone on events.** Verified via `sdef /System/Applications/Calendar.app` — events are floating, with no `time zone` property in the AppleScript dictionary. So a non-local event creates a tension between matching the wall-clock the user typed and firing at the correct absolute moment.

## The Solution

Threaded the timezone through the entire pipeline — model, schema, defaults, and per-platform rendering:

1. **Schema.** Added an optional `timeZone: string` field to both `OpenAICalendarEventSchema` and `GeminiCalendarEventSchema`. The transform normalizes OpenAI's `null` away so consumers always see `string | undefined`. `CalendarEvent.timeZone` defaults to the machine's IANA name in the service layer when the model omits it, so downstream code can rely on the field being present.

2. **Prompt.** Added a `{currentTimezone}` placeholder (e.g. `"Asia/Makassar"`) and a four-step decision procedure: identify the event's location, map it to its IANA timezone using world knowledge, compare to `{currentTimezone}`, and either embed the offset in `startDate`/`endDate` and set `timeZone` (different) or omit them (same). Included Madrid, NYC, and Tokyo examples so the model has explicit shape references.

3. **Date helpers.** Replaced the broken `dropTimezone` with `dateInTimezoneAsLocal(date, timeZone)`, which uses `Intl.DateTimeFormat` to extract the wall-clock parts at the requested timezone and then constructs a "floating" Date from those parts. Added `getCurrentTimezone()` and made `formatGoogleDate` accept an optional `timeZone` parameter.

4. **Per-platform rendering.** Each surface gets the right thing:
   - **Alfred subtitle:** event-TZ wall-clock with a city label (e.g. `From Sun, 13:15 to Sun, 15:15 (Madrid)`) so the time matches what the user typed.
   - **Google Calendar:** dates formatted in the event's timezone and the URL carries `ctz=Europe/Madrid` — proper timezone metadata, correct grid display _and_ correct firing.
   - **Apple Calendar:** branches on whether the event is local or non-local. Local events pass the Date straight to `formatDateToAppleScript`. Non-local events project through `dateInTimezoneAsLocal` so the grid shows the wall-clock the user typed, with `Timezone: <IANA>` appended to the description as a context hint. Apple's lack of a settable `time zone` property means we cannot have both correct grid and correct firing without ICS — this is documented in code comments.

This makes cross-timezone events first-class: typing _"wedding in Madrid at 14:00"_ from Bali correctly produces a Madrid event with the 14:00 wall-clock surfaced everywhere it can be, instead of silently anchoring to the user's local clock.
